### PR TITLE
Image loading refactor

### DIFF
--- a/Client/Components/FnImage.razor
+++ b/Client/Components/FnImage.razor
@@ -1,0 +1,1 @@
+﻿<img src="@srcUrl" class="@CssClass" style="@CssStyle" loading="@lazyLoading" />

--- a/Client/Components/FnImage.razor.cs
+++ b/Client/Components/FnImage.razor.cs
@@ -6,16 +6,17 @@ namespace Functions.Client.Components
     {
         [Parameter] public required Guid FileId { get; set; }
         [Parameter] public string? CssClass { get; set; }
-        [Parameter] public string? CssStyle { get; set; }
+        [Parameter] public string? CssStyle { get; set; } = "max-width: 100%";
         [Parameter] public bool LazyLoading { get; set; } = true;
         [Inject] IConfiguration configuration { get; set; } = default!;
+        [Inject] HttpClient httpClient { get; set; } = default!;
 
         private string? lazyLoading => LazyLoading ? "lazy" : "eager";
         private string srcUrl;
 
         protected override async Task OnParametersSetAsync()
         {
-            srcUrl = configuration["ApiClient:BaseUrl"];
+            srcUrl = httpClient.BaseAddress + "api/file/downloadFile/?file=" + FileId;
         }
     }
 }

--- a/Client/Components/FnImage.razor.cs
+++ b/Client/Components/FnImage.razor.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace Functions.Client.Components
+{
+    public partial class FnImage
+    {
+        [Parameter] public required Guid FileId { get; set; }
+        [Parameter] public string? CssClass { get; set; }
+        [Parameter] public string? CssStyle { get; set; }
+        [Parameter] public bool LazyLoading { get; set; } = true;
+        [Inject] IConfiguration configuration { get; set; } = default!;
+
+        private string? lazyLoading => LazyLoading ? "lazy" : "eager";
+        private string srcUrl;
+
+        protected override async Task OnParametersSetAsync()
+        {
+            srcUrl = configuration["ApiClient:BaseUrl"];
+        }
+    }
+}

--- a/Client/Pages/Event/EventDetail.razor
+++ b/Client/Pages/Event/EventDetail.razor
@@ -1,6 +1,7 @@
 ﻿@page "/events/{eventid:guid}"
 @using Functions.Shared.DTOs
 @using Functions.Shared.Interfaces
+@using Functions.Client.Components
 
 <div class="event-detail" >
     @if (eventItem?.Id != null)
@@ -8,9 +9,9 @@
         <PageTitle>@eventItem.Name</PageTitle>
 
         <div class="event-detail-content">
-            @if (!string.IsNullOrEmpty(eventItem.ProfilePictureBase64))
+            @if (eventItem.FileId != null)
             {
-                <img src="data:image/png;base64,@eventItem.ProfilePictureBase64" class="card-img-top" alt="@eventItem.Name" />
+                <FnImage FileId="@eventItem.FileId.Value" CssClass="card-img-top"/>
             }
 
             <h1>@eventItem.Name</h1>

--- a/Client/Pages/Event/EventList.razor
+++ b/Client/Pages/Event/EventList.razor
@@ -1,6 +1,7 @@
 ﻿@page "/events"
 @using Functions.Shared.DTOs
 @using Functions.Shared.Interfaces
+@using Functions.Client.Components
 
 <PageTitle>Events</PageTitle>
 
@@ -17,9 +18,9 @@
              @foreach (var evt in events)
              {
                 <div class="card">
-                     @if (!string.IsNullOrEmpty(evt.ProfilePictureBase64))
+                     @if (evt.FileId != null && evt.FileId != Guid.Empty)
                      {
-                         <img src="data:image/png;base64,@evt.ProfilePictureBase64" class="card-img-top" alt="@evt.Name" />
+                         <FnImage FileId="@evt.FileId.Value" CssClass=" card-img-top" />
                      }
                      <div class="card-body">
                          <h2 class="card-title">@evt.Name</h2>

--- a/Client/Pages/Event/EventNew.razor.cs
+++ b/Client/Pages/Event/EventNew.razor.cs
@@ -62,10 +62,11 @@ namespace Functions.Client.Pages.Event
                 newEventDescription,
                 newEventStartDateTime,
                 newEventEndDateTime,
+                isPublic,
                 profilePictureBase64,
                 profilePictureFileName,
                 profilePictureContentType,
-                isPublic
+                null
             );
 
             await eventProxy.PostEventAsync(newEvent);

--- a/Server/Controller/FileController.cs
+++ b/Server/Controller/FileController.cs
@@ -1,0 +1,36 @@
+﻿using Functions.Server.Interfaces;
+using Functions.Server.Model;
+using Functions.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
+
+namespace Functions.Server.Controller
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class FileController(IRepository<Files> fileRepository,
+                                IConfiguration configuration) : FunctionsControllerBase(configuration)
+    {
+        [HttpGet("downloadfile")]
+        public async Task<IActionResult> DownloadFile([FromQuery] Guid file)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            var fileEntity = await fileRepository.GetByIdAsync(file);
+            if (fileEntity == null || fileEntity.FileContent == null)
+            {
+                stopwatch.Stop();
+                Console.WriteLine($"DownloadFile execution time: {stopwatch.ElapsedMilliseconds} ms");
+                return NotFound();
+            }
+
+            var fileContent = Convert.FromBase64String(fileEntity.FileContent.Base64Content);
+            var memoryStream = new MemoryStream(fileContent);
+
+            stopwatch.Stop();
+            Console.WriteLine($"DownloadFile execution time: {stopwatch.ElapsedMilliseconds} ms");
+
+            return File(memoryStream, "application/octet-stream", fileEntity.FileName);
+        }
+    }
+}

--- a/Server/Repsitorys/FilesRepository.cs
+++ b/Server/Repsitorys/FilesRepository.cs
@@ -9,12 +9,12 @@ namespace Functions.Server.Repsitorys
     {
         public async Task<IEnumerable<Files>> GetAllAsync()
         {
-            return await context.Files.Include(f => f.FileContent).ToListAsync();
+            return await context.Files.Include(f => f.FileContent).AsNoTracking().ToListAsync();
         }
 
         public async Task<Files> GetByIdAsync(Guid Id)
         {
-            return await context.Files.Include(f => f.FileContent).FirstOrDefaultAsync(f => f.Id == Id);
+            return await context.Files.Include(f => f.FileContent).AsNoTracking().FirstOrDefaultAsync(f => f.Id == Id);
         }
 
         public async Task AddAsync(Files entity)

--- a/Server/UseCases/Event/GetEventByIdUseCase.cs
+++ b/Server/UseCases/Event/GetEventByIdUseCase.cs
@@ -5,7 +5,7 @@ using Functions.Shared.DTOs;
 
 namespace Functions.Server.UseCases.Event
 {
-    public class GetEventByIdUseCase(IRepository<Events> eventRepository, IRepository<Files> fileRepository) : IGetEventByIdUseCase
+    public class GetEventByIdUseCase(IRepository<Events> eventRepository) : IGetEventByIdUseCase
     {
         public async Task<EventsDTO> Handle(Guid id)
         {
@@ -13,16 +13,6 @@ namespace Functions.Server.UseCases.Event
             if (@event == null)
             {
                 throw new ArgumentNullException(nameof(@event));
-            }
-
-            string? base64Image = null;
-            if (@event.PictureId.HasValue)
-            {
-                var file = await fileRepository.GetByIdAsync(@event.PictureId.Value);
-                if (file != null && file.FileContent != null)
-                {
-                    base64Image = file.FileContent.Base64Content;
-                }
             }
 
             return new EventsDTO(
@@ -33,10 +23,11 @@ namespace Functions.Server.UseCases.Event
                 @event.Description ?? string.Empty,
                 @event.StartDateTime,
                 @event.EndDateTime,
-                base64Image,
+                @event.IsPublic,
                 null,
                 null,
-                @event.IsPublic);
+                null,
+                @event.PictureId);
         }
     }
 }

--- a/Server/UseCases/Event/GetEventsUseCase.cs
+++ b/Server/UseCases/Event/GetEventsUseCase.cs
@@ -5,40 +5,24 @@ using Functions.Shared.DTOs;
 
 namespace Functions.Server.UseCases.Event
 {
-    public class GetEventsUseCase(IRepository<Events> eventRepository, IRepository<Files> fileRepository) : IGetEventsUseCase
+    public class GetEventsUseCase(IRepository<Events> eventRepository) : IGetEventsUseCase
     {
         public async Task<List<EventsDTO>> Handle()
         {
             var events = await eventRepository.GetAllAsync();
 
-            var result = new List<EventsDTO>();
-
-            foreach (var e in events)
-            {
-                string? base64Image = null;
-                if (e.PictureId.HasValue)
-                {
-                    var file = await fileRepository.GetByIdAsync(e.PictureId.Value);
-                    if (file != null && file.FileContent != null)
-                    {
-                        base64Image = file.FileContent.Base64Content;
-                    }
-                }
-
-                result.Add(new EventsDTO(
-                    e.Id,
-                    e.Host,
-                    e.Name,
-                    e.Location,
-                    e.Description ?? string.Empty,
-                    e.StartDateTime,
-                    e.EndDateTime,
-                    base64Image,
-                    null,
-                    null,
-                    e.IsPublic
-                ));
-            }
+            var result = events.Select(e => new EventsDTO(
+                Id: e.Id,
+                HostId: e.Host,
+                Name: e.Name,
+                Location: e.Location,
+                Description: e.Description ?? string.Empty,
+                StartDateTime: e.StartDateTime,
+                EndDateTime: e.EndDateTime,
+                isPublic: e.IsPublic,
+                ProfilePictureBase64: null,
+                FileId: e.PictureId
+            )).ToList();
 
             return result;
         }

--- a/Shared/DTOs/EventsDTO.cs
+++ b/Shared/DTOs/EventsDTO.cs
@@ -9,9 +9,10 @@
         string Description,
         DateTime StartDateTime,
         DateTime EndDateTime,
-        string? ProfilePictureBase64,
+        bool isPublic = false,
+        string? ProfilePictureBase64 = null,
         string? FileName = null,
         string? FileType = null,
-        bool isPublic = false
+        Guid? FileId = null
     );
 }


### PR DESCRIPTION
Bilder werden nun nicht mehr per Base64 mit ans Frontend gesendet, sondern werden via Memory Stream an das Frontend gesendet. Da kann der Browser dann selber entscheiden wie und wann das Bild heruntergeladen wird. Dadruch ist die /getAllEvents route deutlich schneller. 

closes #47